### PR TITLE
Paleomons Bug Fixes

### DIFF
--- a/data/mods/paleomons/conditions.ts
+++ b/data/mods/paleomons/conditions.ts
@@ -20,7 +20,6 @@ export const Conditions: {[k: string]: ConditionData} = {
 
 		onStart(battle, source, effect) {
 			if (effect?.effectType === 'Ability') {
-				this.add('-fieldstart', 'move: Tar Pit', '[from] ability: ' + effect, '[of] ' + source);
 				this.add('-message', "The battlefield became a tar pit!");
 				this.hint(`Tar Pit increases the power of Poison-type moves by 1.3x and applies Powder to all Pokemon on the field.`);
 				this.hint(`Doesn't affect grounded Pokemon nor Pokemon holding Heavy-Duty Boots.`);
@@ -40,7 +39,6 @@ export const Conditions: {[k: string]: ConditionData} = {
 		},
 
 		onEnd() {
-			if (!this.effectData.duration) this.eachEvent('Terrain');
 			this.add('-fieldend', 'move: Tar Pit');
 		},
 	},

--- a/data/mods/paleomons/conditions.ts
+++ b/data/mods/paleomons/conditions.ts
@@ -1,0 +1,47 @@
+export const Conditions: {[k: string]: ConditionData} = {	
+	tarpit: {
+		name: "Tar Pit",
+		effectType: 'Terrain',
+		duration: 5,
+		durationCallback(source, effect) {
+			if (source?.hasItem('terrainextender')) {
+				return 8;
+			}
+			return 5;
+		},
+		onBasePowerPriority: 6,
+		onBasePower(basePower, attacker, defender, move) {
+			if (attacker.hasItem('heavydutyboots')) return;
+			if (move.type === 'Poison' && attacker.isGrounded()) {
+				this.debug('tar pit boost');
+				return this.chainModify([0x14CD, 0x1000]);
+			}
+		},
+
+		onStart(battle, source, effect) {
+			if (effect?.effectType === 'Ability') {
+				this.add('-fieldstart', 'move: Tar Pit', '[from] ability: ' + effect, '[of] ' + source);
+				this.add('-message', "The battlefield became a tar pit!");
+				this.hint(`Tar Pit increases the power of Poison-type moves by 1.3x and applies Powder to all Pokemon on the field.`);
+				this.hint(`Doesn't affect grounded Pokemon nor Pokemon holding Heavy-Duty Boots.`);
+			} else {
+				this.add('-fieldstart', 'move: Tar Pit');
+			}
+		},
+
+		onTryMove(pokemon, target, move) {
+			if (move.type === 'Fire') {
+				if (pokemon.isGrounded() && !pokemon.isSemiInvulnerable() && !pokemon.hasItem('heavydutyboots')) {
+					this.add('-message', "When the flame touched the sticky tar on the Pokemon, it combusted!");
+					this.damage(this.clampIntRange(Math.round(pokemon.maxhp / 4), 1));
+					return false;
+				}
+			}
+		},
+
+		onEnd() {
+			if (!this.effectData.duration) this.eachEvent('Terrain');
+			this.add('-fieldend', 'move: Tar Pit');
+		},
+	},
+};

--- a/data/mods/paleomons/conditions.ts
+++ b/data/mods/paleomons/conditions.ts
@@ -20,6 +20,7 @@ export const Conditions: {[k: string]: ConditionData} = {
 
 		onStart(battle, source, effect) {
 			if (effect?.effectType === 'Ability') {
+				this.add('-fieldstart', 'move: Acidic Terrain', '[from] ability: ' + effect, '[of] ' + source);
 				this.add('-message', "The battlefield became a tar pit!");
 				this.hint(`Tar Pit increases the power of Poison-type moves by 1.3x and applies Powder to all Pokemon on the field.`);
 				this.hint(`Doesn't affect grounded Pokemon nor Pokemon holding Heavy-Duty Boots.`);
@@ -37,7 +38,9 @@ export const Conditions: {[k: string]: ConditionData} = {
 				}
 			}
 		},
-
+		
+		onResidualOrder: 21,
+		onResidualSubOrder: 2,
 		onEnd() {
 			this.add('-fieldend', 'move: Tar Pit');
 		},

--- a/data/mods/paleomons/conditions.ts
+++ b/data/mods/paleomons/conditions.ts
@@ -20,8 +20,8 @@ export const Conditions: {[k: string]: ConditionData} = {
 
 		onStart(battle, source, effect) {
 			if (effect?.effectType === 'Ability') {
-				this.add('-fieldstart', 'move: Acidic Terrain', '[from] ability: ' + effect, '[of] ' + source);
-				this.add('-message', "The battlefield became a tar pit!");
+				this.add('-fieldstart', 'move: Tar Pit', '[from] ability: ' + effect, '[of] ' + source);
+				this.add('-message', "The battlefield became coated in tar!");
 				this.hint(`Tar Pit increases the power of Poison-type moves by 1.3x and applies Powder to all Pokemon on the field.`);
 				this.hint(`Doesn't affect grounded Pokemon nor Pokemon holding Heavy-Duty Boots.`);
 			} else {

--- a/data/mods/paleomons/learnsets.ts
+++ b/data/mods/paleomons/learnsets.ts
@@ -1029,7 +1029,7 @@ export const Learnsets: {[speciesid: string]: LearnsetData} = {
 			gunkshot: ["8L1"],
 			poisonjab: ["8L1"],
 			sludgebomb: ["8L1"],
-			tarpit: ["8L1"],
+			//tarpit: ["8L1"],		temporarily removed while Tar Pit is still bugged
 			tarshot: ["8L1"],
 
 			amnesia: ["8M", "8L37"],

--- a/data/mods/paleomons/moves.ts
+++ b/data/mods/paleomons/moves.ts
@@ -66,64 +66,9 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {nonsky: 1},
-
 		onHit(field) {
 			this.field.setTerrain('tarpit');
 		},
-
-		/*condition: {
-			duration: 5,
-			durationCallback(source, effect) {
-				if (source?.hasItem('terrainextender')) {
-					return 8;
-				}
-				return 5;
-			},
-
-			onBasePowerPriority: 6,
-			onBasePower(basePower, attacker, defender, move) {
-				if (attacker.hasItem('heavydutyboots')) return;
-				if (move.type === 'Poison' && attacker.isGrounded()) {
-					this.debug('tar pit boost');
-					return this.chainModify([0x14CD, 0x1000]);
-				}
-			},
-
-			onStart(battle, source, effect) {
-				if (effect?.effectType === 'Ability') {
-					this.add('-fieldstart', 'move: Tar Pit', '[from] ability: ' + effect, '[of] ' + source);
-					this.add('-message', "The battlefield became a tar pit!");
-					this.hint(`Tar Pit increases the power of Poison-type moves by 1.3x and applies Powder to all Pokemon on the field.`);
-					this.hint(`Doesn't affect grounded Pokemon nor Pokemon holding Heavy-Duty Boots.`);
-				} else {
-					this.add('-fieldstart', 'move: Tar Pit');
-				}
-			},
-
-			onTryMove(pokemon, target, move) {
-				if (move.type === 'Fire') {
-					if (pokemon.isGrounded() && !pokemon.isSemiInvulnerable() && !pokemon.hasItem('heavydutyboots')) {
-						this.add('-message', "When the flame touched the sticky tar on the Pokemon, it combusted!");
-						this.damage(this.clampIntRange(Math.round(pokemon.maxhp / 4), 1));
-						return false;
-					}
-				}
-			},
-
-			onEnd() {
-				if (!this.effectData.duration) this.eachEvent('Terrain');
-				this.add('-fieldend', 'move: Tar Pit');
-			},
-		},
-
-		onTryHit(field) {
-			if(this.field.isTerrain(''))
-				return false;
-			else {
-				this.field.clearTerrain();
-			}
-		}, */
-
 		secondary: null,
 		target: "all",
 		type: "Poison",

--- a/data/mods/paleomons/moves.ts
+++ b/data/mods/paleomons/moves.ts
@@ -73,6 +73,15 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			}
 			this.field.setTerrain('tarpit');
 		},
+		condition: {
+			onUpdate() {
+				if (!this.field.isTerrain('tarpit')) {
+					const setTerrain = this.field.getTerrain();
+					this.field.clearTerrain();
+					this.field.setTerrain(setTerrain);
+				}
+			}
+		},
 		secondary: null,
 		target: "all",
 		type: "Poison",

--- a/data/mods/paleomons/moves.ts
+++ b/data/mods/paleomons/moves.ts
@@ -55,7 +55,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		contestType: "Tough",
 	},
 
-	tarpit: {
+	tarpit: { //currently bugged!! ! ):
 		num: -102,
 		accuracy: true,
 		basePower: 0,

--- a/data/mods/paleomons/moves.ts
+++ b/data/mods/paleomons/moves.ts
@@ -69,7 +69,9 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		onHitField(source) {
 			if (this.field.isTerrain('')) return;
 			else {
-				this.field.clearTerrain();
+				for (const terrain of this.field.terrain) {
+					this.field.clearTerrain();
+				}
 			}
 			this.field.setTerrain('tarpit');
 		},

--- a/data/mods/paleomons/moves.ts
+++ b/data/mods/paleomons/moves.ts
@@ -60,14 +60,18 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		accuracy: true,
 		basePower: 0,
 		category: "Status",
-		name: "Tarpit",
+		name: "Tar Pit",
 		desc: "For 5 turns, the terrain becomes a Tar Pit. During the effect, the power of Poison-type attacks used by grounded Pokemon is multiplied by 1.3 and all Pokemon are under the effects of Powder. Camouflage transforms the user into a Poison type, Nature Power becomes Sludge Bomb, and Secret Power has a 30% chance to cause poison. Fails if the current terrain is Tar Pit.",
 		shortDesc: "5 turns. Grounded: +Poison power, +Powder.",
 		pp: 10,
 		priority: 0,
 		flags: {nonsky: 1},
-		terrain: 'tarpit',
-		condition: {
+
+		onHit(field) {
+			this.field.setTerrain('tarpit');
+		},
+
+		/*condition: {
 			duration: 5,
 			durationCallback(source, effect) {
 				if (source?.hasItem('terrainextender')) {
@@ -89,7 +93,8 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				if (effect?.effectType === 'Ability') {
 					this.add('-fieldstart', 'move: Tar Pit', '[from] ability: ' + effect, '[of] ' + source);
 					this.add('-message', "The battlefield became a tar pit!");
-					this.hint(`Tar Pit increases the power of Poison-type moves by 1.3x and applies Powder to all Pokemon on the field. Doesn't affect grounded Pokemon nor Pokemon holding Heavy-Duty Boots.`);
+					this.hint(`Tar Pit increases the power of Poison-type moves by 1.3x and applies Powder to all Pokemon on the field.`);
+					this.hint(`Doesn't affect grounded Pokemon nor Pokemon holding Heavy-Duty Boots.`);
 				} else {
 					this.add('-fieldstart', 'move: Tar Pit');
 				}
@@ -117,7 +122,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			else {
 				this.field.clearTerrain();
 			}
-		},
+		}, */
 
 		secondary: null,
 		target: "all",

--- a/data/mods/paleomons/moves.ts
+++ b/data/mods/paleomons/moves.ts
@@ -71,7 +71,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			else {
 				this.field.clearTerrain();
 			}
-			this.field.setTerrain('tarpit'),
+			this.field.setTerrain('tarpit');
 		},
 		secondary: null,
 		target: "all",

--- a/data/mods/paleomons/moves.ts
+++ b/data/mods/paleomons/moves.ts
@@ -67,6 +67,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		priority: 0,
 		flags: {nonsky: 1},
 		terrain: 'tarpit',
+		effectType: 'Terrain',
 		condition: {
 			duration: 5,
 			durationCallback(source, effect) {
@@ -88,6 +89,8 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			onStart(battle, source, effect) {
 				if (effect?.effectType === 'Ability') {
 					this.add('-fieldstart', 'move: Tar Pit', '[from] ability: ' + effect, '[of] ' + source);
+					this.add('-message', "The battlefield became a tar pit!");
+					this.hint(`Tar Pit increases the power of Poison-type moves by 1.3x and applies Powder to all Pokemon on the field. Doesn't affect grounded Pokemon nor Pokemon holding Heavy-Duty Boots.`);
 				} else {
 					this.add('-fieldstart', 'move: Tar Pit');
 				}

--- a/data/mods/paleomons/moves.ts
+++ b/data/mods/paleomons/moves.ts
@@ -67,7 +67,11 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		priority: 0,
 		flags: {nonsky: 1},
 		onHitField(source) {
-			this.field.setTerrain('tarpit');
+			if (this.field.isTerrain('')) return;
+			else {
+				this.field.clearTerrain();
+			}
+			this.field.setTerrain('tarpit'),
 		},
 		secondary: null,
 		target: "all",

--- a/data/mods/paleomons/moves.ts
+++ b/data/mods/paleomons/moves.ts
@@ -67,7 +67,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		priority: 0,
 		flags: {nonsky: 1},
 		terrain: 'tarpit',
-		effectType: 'Terrain',
 		condition: {
 			duration: 5,
 			durationCallback(source, effect) {
@@ -111,6 +110,15 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				this.add('-fieldend', 'move: Tar Pit');
 			},
 		},
+
+		onTryHit(field) {
+			if(this.field.isTerrain(''))
+				return false;
+			else {
+				this.field.clearTerrain();
+			}
+		},
+
 		secondary: null,
 		target: "all",
 		type: "Poison",

--- a/data/mods/paleomons/moves.ts
+++ b/data/mods/paleomons/moves.ts
@@ -66,7 +66,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {nonsky: 1},
-		onHit(field) {
+		onHitField(source) {
 			this.field.setTerrain('tarpit');
 		},
 		secondary: null,


### PR DESCRIPTION
- Fixed Oozing Tar not overwriting Grassy Terrain
- Tar Pit (the move) still doesn't overwrite terrains properly; it has been removed from Mamoswine-Ancient temporarily 